### PR TITLE
Hide file location details in the api

### DIFF
--- a/examples/nextjs/server.js
+++ b/examples/nextjs/server.js
@@ -5,7 +5,7 @@ const port = parseInt(process.env.PORT, 10) || 3000;
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();
-const createRouteMiddleware = require('@paralleldrive/react-feature-toggles/dist/create-route-middleware');
+const { createRouteMiddleware } = require('@paralleldrive/react-feature-toggles');
 const features = require('./features');
 
 const featureToggleHandler = createRouteMiddleware(features);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 import withFeatures from './with-features';
 import configureFeature from './configure-feature';
-export { withFeatures, configureFeature };
+import createRouteMiddleware from './create-route-middleware';
+
+export { withFeatures, configureFeature, createRouteMiddleware };


### PR DESCRIPTION
We don't want to cause breaking changes by moving around files so having them import it from the main file will allow us to move files around.