### PR TITLE
Add method handlers to express middleware

### DIFF
--- a/examples/nextjs/server.js
+++ b/examples/nextjs/server.js
@@ -8,21 +8,19 @@ const handle = app.getRequestHandler();
 const { createRouteMiddleware } = require('@paralleldrive/react-feature-toggles');
 const features = require('./features');
 
-const featureToggleHandler = createRouteMiddleware(features);
+const createHandler = createRouteMiddleware(features);
 
 app.prepare().then(() => {
   const server = express();
 
   // This will check the feature and set the correct status code for this route.
   // 200 if the feature is enabled, otherwise it will be 404.
-  server.use('/profile', featureToggleHandler('profile'));
-
-  // Then render the profile component at the same path.
-  // This is required. If you let this get to nextjs' default handler it will
-  // override the 404 with a 200 status.
-  server.get('/profile', (req, res) => {
-    return app.render(req, res, '/profile', req.query);
-  });
+  server.use('/profile', createHandler({
+    requiredFeature: 'profile',
+    get: (req, res) => {
+      return app.render(req, res, '/profile', req.query);
+    }
+  }));
 
   server.get('*', (req, res) => {
     return handle(req, res);

--- a/src/create-route-middleware/index.js
+++ b/src/create-route-middleware/index.js
@@ -13,7 +13,7 @@ const createRoute = (features, { requiredFeature, ...methods }) => (req, res, ne
   setStatus(res, getIsEnabled(updatedFeatures, requiredFeature));
 
   const handler = methods[req.method.toLowerCase()];
-  if (handler !== void 1 && typeof handler === 'function') {
+  if (handler !== undefined && typeof handler === 'function') {
     handler(req,res);
   }
 

--- a/src/create-route-middleware/index.js
+++ b/src/create-route-middleware/index.js
@@ -3,15 +3,20 @@ import getIsEnabled from '../utils/get-is-enabled';
 import updateFeatures from '../utils/updateFeaturesWithParams';
 import { parse } from 'url';
 
-const handleResponse = (res, isEnabled) =>
+const setStatus = (res, isEnabled) =>
   isEnabled ? res.status(200) : res.status(404);
 
-const createRoute = (features, featureName) => (req, res, next) => {
+const createRoute = (features, { requiredFeature, ...methods }) => (req, res, next) => {
   const parsedUrl = parse(req.url, true);
   const { search } = parsedUrl;
   const updatedFeatures = updateFeatures(features, search);
+  setStatus(res, getIsEnabled(updatedFeatures, requiredFeature));
 
-  handleResponse(res, getIsEnabled(updatedFeatures, featureName));
+  const handler = methods[req.method.toLowerCase()];
+  if (handler !== void 1 && typeof handler === 'function') {
+    handler(req,res);
+  }
+
   next();
 };
 

--- a/src/create-route-middleware/index.spec.js
+++ b/src/create-route-middleware/index.spec.js
@@ -114,12 +114,11 @@ describe('createRouteMiddleware() auto curried', async should => {
 
   {
     const features = createFeatures();
-    const requiredFeature = 'posts';
-    const middleware = createRouteMiddleware(features)({requiredFeature});
     const req = Request();
     const res = Response();
     const next = Next();
-
+    const middleware = createRouteMiddleware(features)({requiredFeature: 'posts'});
+    
     middleware(req, res, next.next);
 
     assert({

--- a/src/create-route-middleware/index.spec.js
+++ b/src/create-route-middleware/index.spec.js
@@ -3,6 +3,7 @@ import createFeatures from '../test/fixtures/createFeatures';
 import Response from './test/Response';
 import Request from './test/Request';
 import Next from './test/Next';
+import Callback from './test/Callback';
 
 import createRouteMiddleware from './index';
 
@@ -11,12 +12,11 @@ describe('createRouteMiddleware()', async should => {
 
   {
     const features = createFeatures();
-    const featureName = 'posts';
-    const middleware = createRouteMiddleware(features, featureName);
     const req = Request();
     const res = Response();
     const next = Next();
-
+    const middleware = createRouteMiddleware(features, { requiredFeature: 'posts' });
+    
     middleware(req, res, next.next);
 
     assert({
@@ -34,14 +34,15 @@ describe('createRouteMiddleware()', async should => {
     });
   }
 
+  
+
   {
     const features = createFeatures();
-    const featureName = 'help';
-    const middleware = createRouteMiddleware(features, featureName);
-    const req = Request();
+    const req = Request({ method: 'GET' });
     const res = Response();
     const next = Next();
-
+    const middleware = createRouteMiddleware(features, { requiredFeature : 'help' });
+    
     middleware(req, res, next.next);
 
     assert({
@@ -61,12 +62,11 @@ describe('createRouteMiddleware()', async should => {
 
   {
     const features = createFeatures();
-    const featureName = 'help';
-    const middleware = createRouteMiddleware(features, featureName);
     const req = Request({ url: 'http://mydomain.com/help?ft=help' });
     const res = Response();
     const next = Next();
-
+    const middleware = createRouteMiddleware(features, { requiredFeature: 'help' });
+    
     middleware(req, res, next.next);
 
     assert({
@@ -86,12 +86,11 @@ describe('createRouteMiddleware()', async should => {
 
   {
     const features = createFeatures();
-    const featureName = 'help';
-    const middleware = createRouteMiddleware(features, featureName);
     const req = Request({ url: 'http://mydomain.com/help?ft=posts' });
     const res = Response();
     const next = Next();
-
+    const middleware = createRouteMiddleware(features, { requiredFeature: 'help' });
+    
     middleware(req, res, next.next);
 
     assert({
@@ -115,8 +114,8 @@ describe('createRouteMiddleware() auto curried', async should => {
 
   {
     const features = createFeatures();
-    const featureName = 'posts';
-    const middleware = createRouteMiddleware(features)(featureName);
+    const requiredFeature = 'posts';
+    const middleware = createRouteMiddleware(features)({requiredFeature});
     const req = Request();
     const res = Response();
     const next = Next();
@@ -137,4 +136,162 @@ describe('createRouteMiddleware() auto curried', async should => {
       expected: true
     });
   }
+
+  {
+    const features = createFeatures();
+    const getHander = Callback();
+    const req = Request({ method: 'GET' });
+    const res = Response();
+    const next = Next();
+    const middleware = createRouteMiddleware(features, { requiredFeature: 'posts', get: getHander.callback });
+    
+    middleware(req, res, next.next);
+
+    assert({
+      given: 'a feature that is enabled',
+      should: 'have the correct status code for res',
+      actual: res.statusCode,
+      expected: 200
+    });
+
+    assert({
+      given: 'a GET request and a get handler',
+      should: 'call the get handler',
+      actual: getHander.isCalled,
+      expected: true
+    });
+
+    assert({
+      given: 'a GET request and a get handler',
+      should: 'pass the correct arguments to the handler',
+      actual: getHander.args,
+      expected: [req, res]
+    });
+
+    assert({
+      given: 'next callback',
+      should: 'call next after completing',
+      actual: next.valueOf(),
+      expected: true
+    });
+  }
+
+  {
+    const features = createFeatures();
+    const postHander = Callback();
+    const req = Request({ method: 'POST' });
+    const res = Response();
+    const next = Next();
+    const middleware = createRouteMiddleware(features, { requiredFeature: 'posts', post: postHander.callback });
+    
+    middleware(req, res, next.next);
+
+    assert({
+      given: 'a feature that is enabled',
+      should: 'have the correct status code for res',
+      actual: res.statusCode,
+      expected: 200
+    });
+
+    assert({
+      given: 'a POST request and a post handler',
+      should: 'call the post handler',
+      actual: postHander.isCalled,
+      expected: true
+    });
+
+    assert({
+      given: 'a POST request and a post handler',
+      should: 'pass the correct arguments to the handler',
+      actual: postHander.args,
+      expected: [req, res]
+    });
+
+    assert({
+      given: 'next callback',
+      should: 'call next after completing',
+      actual: next.valueOf(),
+      expected: true
+    });
+  }
+
+  {
+    const features = createFeatures();
+    const deleteHander = Callback();
+    const req = Request({ method: 'DELETE' });
+    const res = Response();
+    const next = Next();
+    const middleware = createRouteMiddleware(features, { requiredFeature: 'posts', delete: deleteHander.callback });
+    
+    middleware(req, res, next.next);
+
+    assert({
+      given: 'a feature that is enabled',
+      should: 'have the correct status code for res',
+      actual: res.statusCode,
+      expected: 200
+    });
+
+    assert({
+      given: 'a DELETE request and a delete handler',
+      should: 'call the delete handler',
+      actual: deleteHander.isCalled,
+      expected: true
+    });
+
+    assert({
+      given: 'a DELETE request and a delete handler',
+      should: 'pass the correct arguments to the handler',
+      actual: deleteHander.args,
+      expected: [req, res]
+    });
+
+    assert({
+      given: 'next callback',
+      should: 'call next after completing',
+      actual: next.valueOf(),
+      expected: true
+    });
+  }
+
+  {
+    const features = createFeatures();
+    const putHander = Callback();
+    const req = Request({ method: 'PUT' });
+    const res = Response();
+    const next = Next();
+    const middleware = createRouteMiddleware(features, { requiredFeature: 'posts', put: putHander.callback });
+    
+    middleware(req, res, next.next);
+
+    assert({
+      given: 'a feature that is enabled',
+      should: 'have the correct status code for res',
+      actual: res.statusCode,
+      expected: 200
+    });
+
+    assert({
+      given: 'a PUT request and a put handler',
+      should: 'call the put handler',
+      actual: putHander.isCalled,
+      expected: true
+    });
+
+    assert({
+      given: 'a PUT request and a put handler',
+      should: 'pass the correct arguments to the handler',
+      actual: putHander.args,
+      expected: [req, res]
+    });
+
+    assert({
+      given: 'next callback',
+      should: 'call next after completing',
+      actual: next.valueOf(),
+      expected: true
+    });
+  }
+
 });
+

--- a/src/create-route-middleware/test/Callback.js
+++ b/src/create-route-middleware/test/Callback.js
@@ -1,0 +1,10 @@
+const callback = (called = false, args = []) => ({
+  callback: (...argsv) => {
+    called = true;
+    args = argsv;
+  },
+  get isCalled () { return called; },
+  get args() { return args; }
+});
+
+export default callback;

--- a/src/create-route-middleware/test/Request.js
+++ b/src/create-route-middleware/test/Request.js
@@ -1,7 +1,9 @@
 const Request = ({
-  url = ''
+  url = '',
+  method = 'GET'
 }={}) => ({
-  get url() { return url; }
+  get url() { return url; },
+  get method() { return method; }
 });
 
 export default Request;

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,4 +1,4 @@
-import '../utils/test';
-import '../with-features/test';
-import '../configure-feature/test';
+// import '../utils/test';
+// import '../with-features/test';
+// import '../configure-feature/test';
 import '../create-route-middleware/index.spec';

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,4 +1,4 @@
-// import '../utils/test';
-// import '../with-features/test';
-// import '../configure-feature/test';
+import '../utils/test';
+import '../with-features/test';
+import '../configure-feature/test';
 import '../create-route-middleware/index.spec';


### PR DESCRIPTION
Based on @ericelliott [comment](https://github.com/paralleldrive/react-feature-toggles/pull/57#discussion_r150424032)

Added the ability to combine the route handler and the middleware in one `server.use` call.