### PR TITLE
[Fixes #67] Fix util importing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,13 @@
 import withFeatures from './with-features';
 import configureFeature from './configure-feature';
 import createRouteMiddleware from './create-route-middleware';
+import getIsEnabled from './utils/get-is-enabled';
+import getEnabled from './utils/get-enabled';
 
-export { withFeatures, configureFeature, createRouteMiddleware };
+export {
+  withFeatures,
+  configureFeature,
+  createRouteMiddleware,
+  getIsEnabled,
+  getEnabled
+};


### PR DESCRIPTION
fixes #67

- Adds `getIsEnabled` and `getEnabled` to the API so imports do not need to traverse the directory structure for them.