### PR TITLE
Delete documentation about the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,15 +164,3 @@ import { getIsEnabled } from '@paralleldrive/react-feature-toggles';
 
 const helpIsEnabled = getIsEnabled(features, 'help');
 ```
-
-## Enabling a feature from the url
-
-**NOTE:** If you are using server rendering then overriding features from the url will cause React to throw a warning that the client-side HTML result is different from the server.
-
-Add comma-separated names to the `ft` search param. `?ft=FEATURE_NAME,FEATURE_NAME`
-
-**example**
-
-```
-http://www.example.com/?ft=help,comments
-```


### PR DESCRIPTION
Since this library no longer directly grabs the query from the url and the query object now needs to be provided. I don't think it makes sense for the docs to contain this information in this format.

I think we need to create a more informative `query` section.