### PR TITLE
remove getIsEnabled from the public API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import createRouteMiddleware from './create-route-middleware';
-import getIsEnabled from './get-is-enabled';
 import getEnabledFeatures from './get-enabled-features';
 import updateFeaturesWithQuery from './update-features-with-query';
 
@@ -13,7 +12,6 @@ export { parseQuery } from './parse-query';
 
 export {
   createRouteMiddleware,
-  getIsEnabled,
   getEnabledFeatures,
   updateFeaturesWithQuery
 };


### PR DESCRIPTION
This function doesn't need to be a part of the public api.