### PR TITLE
Updates StatelessComponent to SFC in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,7 @@
 declare module '@paralleldrive/react-feature-toggles' {
-  import { ComponentClass, StatelessComponent } from 'react';
+  import { ComponentClass, SFC } from 'react';
   type FeatureNames = ReadonlyArray<string>;
-  type Component = ComponentClass | StatelessComponent;
+  type Component = ComponentClass | SFC<any>;
 
   export function Feature(props: {
     children: (args: { features: FeatureNames }) => JSX.Element;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,7 @@
 declare module '@paralleldrive/react-feature-toggles' {
-  import { ComponentClass, SFC } from 'react';
+  import { ComponentClass, SFC, StatelessComponent } from 'react';
   type FeatureNames = ReadonlyArray<string>;
-  type Component = ComponentClass | SFC<any>;
+  type Component = ComponentClass | SFC<any> | StatelessComponent;
 
   export function Feature(props: {
     children: (args: { features: FeatureNames }) => JSX.Element;


### PR DESCRIPTION
The below component was not compatible with the StatelessComponent type. 
```ts
const test = (props: any) => (<div>{props}</div>)
```
Using SFC instead fixed the issue. It is defined in `@types/react/index/d.ts`
```ts
type SFC<P> = StatelessComponent<P>;
interface StatelessComponent<P> {
 (props: P & { children?: ReactNode }, context?: any): ReactElement<any>;
 propTypes?: ValidationMap<P>;
 contextTypes?: ValidationMap<any>;
 defaultProps?: Partial<P>;
 displayName?: string;
}
```
[Reference](https://medium.com/@ethan_ikt/react-stateless-functional-component-with-typescript-ce5043466011)