### PR TITLE
Add withFeatures() and useFeatures() alternative APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,36 @@ const myPage = () => (
 );
 ```
 
+#### withFeatures
+
+If you'd prefer to directly access the list of active Features, you can obtain a `features` prop with the HoC:
+
+```js
+import { withFeatures } from '@paralleldrive/react-feature-toggles';
+
+function MyButton({ title, features }) {
+    return (
+        <Button disabled={features.includes('disable-login-button')}>{title}</Button>
+    );
+}
+export default withFeatures(MyButton);
+```
+
+#### useFeatures
+
+If you're using React >= 16.8, you can access the active Features with the `useFeatures()` hook:
+
+```js
+import { useFeatures } from '@paralleldrive/react-feature-toggles';
+
+export default function MyButton({ title }) {
+    const features = useFeatures();
+    return (
+        <Button disabled={features.includes('disable-login-button')}>{title}</Button>
+    );
+}
+```
+
 ## Enabling features from the URL
 
 In v2, query logic has been moved out of the provider component. You should now handle this logic before passing features to `FeatureToggles`

--- a/src/context.js
+++ b/src/context.js
@@ -1,3 +1,21 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
-export const { Consumer, Provider } = React.createContext([]);
+const FeaturesContext = React.createContext([]);
+
+export const { Consumer, Provider } = FeaturesContext;
+
+export function useFeatures() {
+  return useContext(FeaturesContext);
+}
+
+export function withFeatures(Component) {
+  return props => {
+    return (
+      <FeaturesContext.Consumer>
+        {features => (
+          <Component {...props} features={features ? features : {}} />
+        )}
+      </FeaturesContext.Consumer>
+    );
+  };
+}

--- a/src/context.js
+++ b/src/context.js
@@ -1,21 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
-const FeaturesContext = React.createContext([]);
-
-export const { Consumer, Provider } = FeaturesContext;
-
-export function useFeatures() {
-  return useContext(FeaturesContext);
-}
-
-export function withFeatures(Component) {
-  return props => {
-    return (
-      <FeaturesContext.Consumer>
-        {features => (
-          <Component {...props} features={features ? features : {}} />
-        )}
-      </FeaturesContext.Consumer>
-    );
-  };
-}
+export const FeatureTogglesContext = React.createContext([]);
+export const { Consumer, Provider } = FeatureTogglesContext;

--- a/src/context.test.js
+++ b/src/context.test.js
@@ -1,0 +1,137 @@
+import { describe } from 'riteway';
+import dom from 'cheerio';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+
+import { Provider, withFeatures, useFeatures } from './context';
+
+const render = ReactDOMServer.renderToStaticMarkup;
+
+describe('withFeatures()', async assert => {
+  {
+    const TestComponentWithHoC = withFeatures(({ features }) => {
+      return (
+        <div className={features.includes('foo') ? 'flag-on' : 'flag-off'} />
+      );
+    });
+
+    const features = ['foo', 'bar', 'baz'];
+
+    const $ = dom.load(
+      render(
+        <Provider value={features}>
+          <TestComponentWithHoC />
+        </Provider>
+      )
+    );
+
+    assert({
+      given: 'the feature is enabled and a HoC wrapped component',
+      should: 'render the flag enabled component',
+      actual: $('.flag-on').length,
+      expected: 1
+    });
+
+    assert({
+      given: 'the feature is enabled and a HoC wrapped component',
+      should: 'not render the flag disabled component',
+      actual: $('.flag-off').length,
+      expected: 0
+    });
+  }
+  {
+    const TestComponentWithHoC = withFeatures(({ features }) => {
+      return (
+        <div className={features.includes('foo') ? 'flag-on' : 'flag-off'} />
+      );
+    });
+
+    const features = ['not-foo', 'bar', 'baz'];
+
+    const $ = dom.load(
+      render(
+        <Provider value={features}>
+          <TestComponentWithHoC />
+        </Provider>
+      )
+    );
+
+    assert({
+      given: 'the feature is disabled and a HoC wrapped component',
+      should: 'not render the flag enabled component',
+      actual: $('.flag-on').length,
+      expected: 0
+    });
+
+    assert({
+      given: 'the feature is enabled and a HoC wrapped component',
+      should: 'render the flag disabled component',
+      actual: $('.flag-off').length,
+      expected: 1
+    });
+  }
+  {
+    const TestComponentWithHook = () => {
+      const features = useFeatures();
+      return (
+        <div className={features.includes('foo') ? 'flag-on' : 'flag-off'} />
+      );
+    };
+
+    const features = ['foo', 'bar', 'baz'];
+
+    const $ = dom.load(
+      render(
+        <Provider value={features}>
+          <TestComponentWithHook />
+        </Provider>
+      )
+    );
+
+    assert({
+      given: 'the feature is disabled and a hooked component',
+      should: 'render the flag enabled component',
+      actual: $('.flag-on').length,
+      expected: 1
+    });
+
+    assert({
+      given: 'the feature is enabled and a hooked component',
+      should: 'not render the flag disabled component',
+      actual: $('.flag-off').length,
+      expected: 0
+    });
+  }
+  {
+    const TestComponentWithHook = () => {
+      const features = useFeatures();
+      return (
+        <div className={features.includes('foo') ? 'flag-on' : 'flag-off'} />
+      );
+    };
+
+    const features = ['not-foo', 'bar', 'baz'];
+
+    const $ = dom.load(
+      render(
+        <Provider value={features}>
+          <TestComponentWithHook />
+        </Provider>
+      )
+    );
+
+    assert({
+      given: 'the feature is disabled and a hooked component',
+      should: 'not render the flag enabled component',
+      actual: $('.flag-on').length,
+      expected: 0
+    });
+
+    assert({
+      given: 'the feature is enabled and a hooked component',
+      should: 'render the flag disabled component',
+      actual: $('.flag-off').length,
+      expected: 1
+    });
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,9 @@ export { configureFeature } from './configure-feature';
 export { FeatureToggles } from './feature-toggles';
 export { Feature } from './feature';
 export { withFeatureToggles } from './with-feature-toggles';
+export {
+  withFeatures,
+  useFeatures,
+  Consumer as FeaturesConsumer,
+  Provider as FeaturesProvider
+} from './context';

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,6 @@ export { configureFeature } from './configure-feature';
 export { FeatureToggles } from './feature-toggles';
 export { Feature } from './feature';
 export { withFeatureToggles } from './with-feature-toggles';
-export {
-  withFeatures,
-  useFeatures,
-  Consumer as FeaturesConsumer,
-  Provider as FeaturesProvider
-} from './context';
+export { FeatureTogglesContext } from './context';
+export { withFeatures } from './with-features';
+export { useFeatures } from './use-features';

--- a/src/use-features.js
+++ b/src/use-features.js
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { FeatureTogglesContext } from './context';
+
+export const useFeatures = () => useContext(FeatureTogglesContext);

--- a/src/use-features.test.js
+++ b/src/use-features.test.js
@@ -1,0 +1,76 @@
+import { describe } from 'riteway';
+import dom from 'cheerio';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+
+import { Provider } from './context';
+import { useFeatures } from './use-features';
+
+const render = ReactDOMServer.renderToStaticMarkup;
+
+describe('useFeatures()', async assert => {
+  {
+    const TestComponentWithHook = () => {
+      const features = useFeatures();
+      return (
+        <div className={features.includes('foo') ? 'flag-on' : 'flag-off'} />
+      );
+    };
+
+    const features = ['foo', 'bar', 'baz'];
+
+    const $ = dom.load(
+      render(
+        <Provider value={features}>
+          <TestComponentWithHook />
+        </Provider>
+      )
+    );
+
+    assert({
+      given: 'the feature is disabled and a hooked component',
+      should: 'render the flag enabled component',
+      actual: $('.flag-on').length,
+      expected: 1
+    });
+
+    assert({
+      given: 'the feature is enabled and a hooked component',
+      should: 'not render the flag disabled component',
+      actual: $('.flag-off').length,
+      expected: 0
+    });
+  }
+  {
+    const TestComponentWithHook = () => {
+      const features = useFeatures();
+      return (
+        <div className={features.includes('foo') ? 'flag-on' : 'flag-off'} />
+      );
+    };
+
+    const features = ['not-foo', 'bar', 'baz'];
+
+    const $ = dom.load(
+      render(
+        <Provider value={features}>
+          <TestComponentWithHook />
+        </Provider>
+      )
+    );
+
+    assert({
+      given: 'the feature is disabled and a hooked component',
+      should: 'not render the flag enabled component',
+      actual: $('.flag-on').length,
+      expected: 0
+    });
+
+    assert({
+      given: 'the feature is enabled and a hooked component',
+      should: 'render the flag disabled component',
+      actual: $('.flag-off').length,
+      expected: 1
+    });
+  }
+});

--- a/src/with-features.js
+++ b/src/with-features.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { FeatureTogglesContext } from './context';
+
+export const withFeatures = Component => props => {
+	return (
+		<FeatureTogglesContext.Consumer>
+			{features => (
+				<Component {...props} features={features}/>
+			)}
+		</FeatureTogglesContext.Consumer>
+	);
+};

--- a/src/with-features.test.js
+++ b/src/with-features.test.js
@@ -3,7 +3,8 @@ import dom from 'cheerio';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
-import { Provider, withFeatures, useFeatures } from './context';
+import { Provider } from './context';
+import { withFeatures } from './with-features';
 
 const render = ReactDOMServer.renderToStaticMarkup;
 
@@ -65,70 +66,6 @@ describe('withFeatures()', async assert => {
 
     assert({
       given: 'the feature is enabled and a HoC wrapped component',
-      should: 'render the flag disabled component',
-      actual: $('.flag-off').length,
-      expected: 1
-    });
-  }
-  {
-    const TestComponentWithHook = () => {
-      const features = useFeatures();
-      return (
-        <div className={features.includes('foo') ? 'flag-on' : 'flag-off'} />
-      );
-    };
-
-    const features = ['foo', 'bar', 'baz'];
-
-    const $ = dom.load(
-      render(
-        <Provider value={features}>
-          <TestComponentWithHook />
-        </Provider>
-      )
-    );
-
-    assert({
-      given: 'the feature is disabled and a hooked component',
-      should: 'render the flag enabled component',
-      actual: $('.flag-on').length,
-      expected: 1
-    });
-
-    assert({
-      given: 'the feature is enabled and a hooked component',
-      should: 'not render the flag disabled component',
-      actual: $('.flag-off').length,
-      expected: 0
-    });
-  }
-  {
-    const TestComponentWithHook = () => {
-      const features = useFeatures();
-      return (
-        <div className={features.includes('foo') ? 'flag-on' : 'flag-off'} />
-      );
-    };
-
-    const features = ['not-foo', 'bar', 'baz'];
-
-    const $ = dom.load(
-      render(
-        <Provider value={features}>
-          <TestComponentWithHook />
-        </Provider>
-      )
-    );
-
-    assert({
-      given: 'the feature is disabled and a hooked component',
-      should: 'not render the flag enabled component',
-      actual: $('.flag-on').length,
-      expected: 0
-    });
-
-    assert({
-      given: 'the feature is enabled and a hooked component',
       should: 'render the flag disabled component',
       actual: $('.flag-off').length,
       expected: 1

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,5 +1,7 @@
 import '../src/configure-feature.test';
 import '../src/feature-toggles.test';
 import '../src/feature.test';
+import '../src/use-features.test';
 import '../src/with-feature-toggles.test';
+import '../src/with-features.test';
 import '../src/curry.test';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,4 +21,10 @@ declare module '@paralleldrive/react-feature-toggles' {
   export function configureFeature(
     inactiveComponent: Component
   ): (name: string) => (activeComponent: Component) => Component;
+
+  export function withFeatures(
+      component: Component
+  ): any;
+
+  export function useFeatures(): FeatureNames;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 declare module '@paralleldrive/react-feature-toggles' {
-  import { ComponentClass, SFC, StatelessComponent } from 'react';
+  import { ComponentClass, SFC, StatelessComponent, Provider, Consumer } from 'react';
   type FeatureNames = ReadonlyArray<string>;
   type Component = ComponentClass | SFC<any> | StatelessComponent;
 
@@ -21,6 +21,12 @@ declare module '@paralleldrive/react-feature-toggles' {
   export function configureFeature(
     inactiveComponent: Component
   ): (name: string) => (activeComponent: Component) => Component;
+
+  export interface FeatureTogglesContext<T> {
+    Provider: Provider<T>;
+    Consumer: Consumer<T>;
+    displayName?: string;
+  }
 
   export function withFeatures(
       component: Component


### PR DESCRIPTION
We've several use cases where we'd like to use Feature Toggles to gate off functionality that isn't well suited to the "activeComponent" vs "inactiveComponent" pattern, however the raw list of enabled Features isn't well exposed, nor is the ContextConsumer.

This adds a HoC `withFeatures()` and a `useFeatures()` Hook, both simply using the FeaturesConsumer to expose the `features` array, along with exposing the Provider/Consumer for advanced use cases.

I've included examples in the README.md changes, plus new tests.